### PR TITLE
Rely default ConsoleRenderer constructor

### DIFF
--- a/google_structlog/setup_stdout.py
+++ b/google_structlog/setup_stdout.py
@@ -12,9 +12,7 @@ def setup_stdout_logger(
   logger.setLevel(loglevel)
 
   formatter = structlog.stdlib.ProcessorFormatter(
-    processor=structlog.dev.ConsoleRenderer(
-      colors=True
-    ),
+    processor=structlog.dev.ConsoleRenderer(),
   )
 
   handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
This change should allow the default constructor of the ConsoleRenderer to determine if colors should be requested or not based on presence of colorama as a dependency. Should work the same if present but allow this library to be used out of the box without adding it as a requirement.